### PR TITLE
fix: Fixed offset issue

### DIFF
--- a/src/orders/services.py
+++ b/src/orders/services.py
@@ -57,7 +57,7 @@ class OrdersService:
             CartItemsModel.cart_item_id.in_(cart_item_ids),
         ]
         cart_items = self._cart_items_repository.get_cart_items(
-            user_id, len(cart_item_ids), *filters
+            user_id, len(cart_item_ids), 0, *filters
         )
         if not cart_items:
             raise NotFoundException(


### PR DESCRIPTION
Getting the following error while checking out order

`sqlalchemy.exc.ProgrammingError: (psycopg2.errors.DatatypeMismatch) argument of OFFSET must be type bigint, not type boolean`

Traceback
```
backend  |              ^^^^^^^^^^^^^^^^^^^^^^^^
backend  |   File "/app/src/orders/controllers.py", line 48, in checkout_order
backend  |     ).checkout_order(user_id, cart_item_ids)
backend  |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend  |   File "/app/src/orders/services.py", line 59, in checkout_order
backend  |     cart_items = self._cart_items_repository.get_cart_items(
backend  |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend  |   File "/app/src/repositories/carts/models.py", line 101, in get_cart_items
backend  |     return session.scalars(stmt).all()
```