### PR TITLE
Fix Response imports

### DIFF
--- a/src/authors/services.py
+++ b/src/authors/services.py
@@ -1,4 +1,4 @@
-from fastapi.openapi.models import Response
+from fastapi import Response
 
 from common.helper import to_dict
 from common.schemas import ErrorSchema

--- a/src/publishers/services.py
+++ b/src/publishers/services.py
@@ -1,4 +1,4 @@
-from fastapi.openapi.models import Response
+from fastapi import Response
 
 from common.helper import to_dict
 from common.schemas import ErrorSchema


### PR DESCRIPTION
## Summary
- import `Response` from FastAPI instead of the OpenAPI models

## Testing
- `ruff check src/authors/services.py src/publishers/services.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fd64abd10832bb6065b61b901ab4b