### PR TITLE
Fix typo in development setup heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker compose up -d
 http://localhost:8545/docs
 
 
-## Developmemt Setup
+## Development Setup
 Install the following.
 1. Python 3.12.8
 2. [Poetry](https://python-poetry.org/docs/#installation)


### PR DESCRIPTION
## Summary
- fix `Developmemt Setup` heading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f22df470832b9101f3b313a79312