### PR TITLE
Add expanded fixture data

### DIFF
--- a/src/tests/fixtures/cart_items.json
+++ b/src/tests/fixtures/cart_items.json
@@ -1,0 +1,12 @@
+[
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "17ca16b8-b0f3-48d3-97e6-5d6bc5a8d747", "cart_id": "38c677f2-8f04-4bf7-8003-1b413fb4317f", "book_id": "b1f8b2ef", "quantity": 1}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "bec41712-70d8-4349-9fde-52f87f8f0831", "cart_id": "70182673-c0dd-43ab-9071-c8920920948e", "book_id": "bji5bqsr", "quantity": 2}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "13a215d5-ac75-450f-b89e-ab4d618e889e", "cart_id": "5a035da1-7b25-4994-8c44-8298a0d87404", "book_id": "b1f8b2ef", "quantity": 1}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "c5f69fd9-2db4-4750-b8b5-0df4c1fff307", "cart_id": "cc032c5e-964b-4c4f-846f-d61a3adc1685", "book_id": "bji5bqsr", "quantity": 3}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "fa7a35b2-ab5e-468e-89de-b65b907a186d", "cart_id": "89162187-66bc-4b25-af3a-4abf81ead312", "book_id": "b1f8b2ef", "quantity": 2}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "e3e713be-2dd4-4cc8-a75d-a95801c9b453", "cart_id": "38da55b6-0917-4e71-b80d-5781686b67e8", "book_id": "bji5bqsr", "quantity": 1}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "b85a5728-8da1-47b8-b7f9-cc3a0e8a5156", "cart_id": "a639cb87-76bf-44d6-99be-3b54d8b5b4d9", "book_id": "b1f8b2ef", "quantity": 1}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "f631bce3-0a66-411e-9614-18f4f83ace2f", "cart_id": "06bdfa9a-d61d-458d-862b-e94087823cb5", "book_id": "bji5bqsr", "quantity": 2}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "08d5f4b2-d948-4737-9ff9-87bc001dce69", "cart_id": "9f8979bb-3f49-4e65-bdd3-da9dc7204e39", "book_id": "b1f8b2ef", "quantity": 3}},
+  {"model": "repositories.carts.models.CartItemsModel", "field": {"cart_item_id": "cf39f616-874d-4792-8c75-8bc20dd36ddb", "cart_id": "1f4c08d9-3783-4804-a4f8-db26605669d6", "book_id": "bji5bqsr", "quantity": 1}}
+]

--- a/src/tests/fixtures/carts.json
+++ b/src/tests/fixtures/carts.json
@@ -1,0 +1,42 @@
+[
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "38c677f2-8f04-4bf7-8003-1b413fb4317f", "user_id": "36803905-cd33-484c-8e53-e1de79201e4b"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "70182673-c0dd-43ab-9071-c8920920948e", "user_id": "7b26c884-75e5-481e-9b6e-3ea45b445cd3"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "5a035da1-7b25-4994-8c44-8298a0d87404", "user_id": "4df58099-e3aa-4d6f-953d-50f2786cb99a"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "cc032c5e-964b-4c4f-846f-d61a3adc1685", "user_id": "9bea8bf5-f985-4388-aec4-abfb46fc0ece"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "89162187-66bc-4b25-af3a-4abf81ead312", "user_id": "bf0573e4-d1d7-497c-bb36-f0bf15025d83"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "38da55b6-0917-4e71-b80d-5781686b67e8", "user_id": "aa8ae292-0e16-4eed-aaf1-55f34b4fcebc"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "a639cb87-76bf-44d6-99be-3b54d8b5b4d9", "user_id": "1eeae224-abb3-47a9-9e98-4b6124d45da4"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "06bdfa9a-d61d-458d-862b-e94087823cb5", "user_id": "b7c8c496-a2f6-4bc9-8b62-84d5aebb73b5"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "9f8979bb-3f49-4e65-bdd3-da9dc7204e39", "user_id": "88244ce5-d1ee-455f-a265-c100ef3805c5"}
+  },
+  {
+    "model": "repositories.carts.models.CartsModel",
+    "field": {"cart_id": "1f4c08d9-3783-4804-a4f8-db26605669d6", "user_id": "131d1e08-77aa-440d-a7ea-74aed737537c"}
+  }
+]

--- a/src/tests/fixtures/order_items.json
+++ b/src/tests/fixtures/order_items.json
@@ -1,0 +1,10 @@
+[
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "9ea28a9c-2a47-4f59-9516-f607b7a9e1c6", "order_id": "BO24064JSJA9", "book_id": "b1f8b2ef", "quantity": 1, "total_amount": 10.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "28483bc5-5293-4bc7-943c-9e185c662bfb", "order_id": "BO2406Q6WU1E", "book_id": "bji5bqsr", "quantity": 2, "total_amount": 40.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "3bcc4622-8b02-40d3-a40e-e028733a1b20", "order_id": "BO240613LIQL", "book_id": "b1f8b2ef", "quantity": 2, "total_amount": 20.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "e5070431-707c-4cdb-8068-d620b637ff81", "order_id": "BO2406CM8VI7", "book_id": "bji5bqsr", "quantity": 3, "total_amount": 60.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "d2997546-3fa4-4042-abd8-3310b304934b", "order_id": "BO2406D0XNF0", "book_id": "b1f8b2ef", "quantity": 2, "total_amount": 20.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "d1029cdf-950d-4365-a951-4a15ffd13722", "order_id": "BO2406G10Y6H", "book_id": "bji5bqsr", "quantity": 2, "total_amount": 20.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "930dbd1b-3dd5-48cc-bd71-76acbdabe65e", "order_id": "BO2406YUV1FM", "book_id": "b1f8b2ef", "quantity": 5, "total_amount": 50.0}},
+  {"model": "repositories.orders.models.OrderItemsModel", "field": {"order_item_id": "d23d507f-df3b-4c9c-b362-3f97c75c26e5", "order_id": "BO24066RVCB5", "book_id": "bji5bqsr", "quantity": 3, "total_amount": 30.0}}
+]

--- a/src/tests/fixtures/orders.json
+++ b/src/tests/fixtures/orders.json
@@ -1,0 +1,10 @@
+[
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO24064JSJA9", "user_id": "36803905-cd33-484c-8e53-e1de79201e4b", "total_amount": 10.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO2406Q6WU1E", "user_id": "7b26c884-75e5-481e-9b6e-3ea45b445cd3", "total_amount": 40.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO240613LIQL", "user_id": "4df58099-e3aa-4d6f-953d-50f2786cb99a", "total_amount": 20.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO2406CM8VI7", "user_id": "9bea8bf5-f985-4388-aec4-abfb46fc0ece", "total_amount": 60.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO2406D0XNF0", "user_id": "bf0573e4-d1d7-497c-bb36-f0bf15025d83", "total_amount": 20.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO2406G10Y6H", "user_id": "aa8ae292-0e16-4eed-aaf1-55f34b4fcebc", "total_amount": 20.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO2406YUV1FM", "user_id": "1eeae224-abb3-47a9-9e98-4b6124d45da4", "total_amount": 50.0, "status": "pending"}},
+  {"model": "repositories.orders.models.OrdersModel", "field": {"order_id": "BO24066RVCB5", "user_id": "88244ce5-d1ee-455f-a265-c100ef3805c5", "total_amount": 30.0, "status": "pending"}}
+]

--- a/src/tests/fixtures/users.json
+++ b/src/tests/fixtures/users.json
@@ -1,0 +1,122 @@
+[
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "36803905-cd33-484c-8e53-e1de79201e4b",
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "john.doe@example.com",
+            "isd_code": "+1",
+            "phone": "1000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "7b26c884-75e5-481e-9b6e-3ea45b445cd3",
+            "first_name": "Jane",
+            "last_name": "Smith",
+            "email": "jane.smith@example.com",
+            "isd_code": "+1",
+            "phone": "2000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "4df58099-e3aa-4d6f-953d-50f2786cb99a",
+            "first_name": "Alice",
+            "last_name": "Brown",
+            "email": "alice.brown@example.com",
+            "isd_code": "+44",
+            "phone": "3000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "9bea8bf5-f985-4388-aec4-abfb46fc0ece",
+            "first_name": "Bob",
+            "last_name": "Johnson",
+            "email": "bob.johnson@example.com",
+            "isd_code": "+44",
+            "phone": "4000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "bf0573e4-d1d7-497c-bb36-f0bf15025d83",
+            "first_name": "Carol",
+            "last_name": "Davis",
+            "email": "carol.davis@example.com",
+            "isd_code": "+91",
+            "phone": "5000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "aa8ae292-0e16-4eed-aaf1-55f34b4fcebc",
+            "first_name": "David",
+            "last_name": "Miller",
+            "email": "david.miller@example.com",
+            "isd_code": "+91",
+            "phone": "6000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "1eeae224-abb3-47a9-9e98-4b6124d45da4",
+            "first_name": "Eve",
+            "last_name": "Wilson",
+            "email": "eve.wilson@example.com",
+            "isd_code": "+81",
+            "phone": "7000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "b7c8c496-a2f6-4bc9-8b62-84d5aebb73b5",
+            "first_name": "Frank",
+            "last_name": "Taylor",
+            "email": "frank.taylor@example.com",
+            "isd_code": "+81",
+            "phone": "8000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "88244ce5-d1ee-455f-a265-c100ef3805c5",
+            "first_name": "Grace",
+            "last_name": "Anderson",
+            "email": "grace.anderson@example.com",
+            "isd_code": "+61",
+            "phone": "9000000000",
+            "is_guest": false
+        }
+    },
+    {
+        "model": "repositories.users.models.UsersModel",
+        "field": {
+            "user_id": "131d1e08-77aa-440d-a7ea-74aed737537c",
+            "first_name": "Henry",
+            "last_name": "Thomas",
+            "email": "henry.thomas@example.com",
+            "isd_code": "+61",
+            "phone": "1000000001",
+            "is_guest": false
+        }
+    }
+]


### PR DESCRIPTION
## Summary
- add JSON fixtures for users, carts, cart items, orders and order items
- populate each file with sample objects referencing one another

## Testing
- `pre-commit run --files src/tests/fixtures/users.json src/tests/fixtures/carts.json src/tests/fixtures/cart_items.json src/tests/fixtures/orders.json src/tests/fixtures/order_items.json`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d618f344832bba9d2c791b8d0d0d